### PR TITLE
Fixes #1 broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   ],
   "keywords": [
     "bespoke-plugin",
-    "markdwon"
+    "markdown"
   ]
 }

--- a/test/spec/bespoke-markdownSpec.js
+++ b/test/spec/bespoke-markdownSpec.js
@@ -11,7 +11,7 @@ describe("bespoke-markdown", function() {
       var parent = document.createElement('article');
       for (var i = 0; i < 10; i++) {
         var slide = document.createElement('section');
-        slide.innerHTML = '# ' + i;
+        slide.innerHTML = 'just a __bold__ text ' + i;
         parent.appendChild(slide);
       }
 
@@ -29,7 +29,7 @@ describe("bespoke-markdown", function() {
     });
 
     it("should have parsed the slide from markdown to html", function() {
-      expect(deck.slides[0].innerHTML).toBe('<h1>1</h1>');
+      expect(deck.slides[0].innerHTML.trim()).toBe('<p>just a <strong>bold</strong> text 0</p>');
     });
 
   });


### PR DESCRIPTION
Changes the test so it doesn't use the generation of h1...h6 tags, but just a plain paragraph.

That way, we avoid to test the generation of tag ids that became a default on a newer version of [marked](https://github.com/chjj/marked) for h1...h6 tags.
